### PR TITLE
Upgrade to v5.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shall NOT be edited by hand.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Shipped version:** 5.5.0~ynh1
+**Shipped version:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ No se debe editar a mano.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Versión actual:** 5.5.0~ynh1
+**Versión actual:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ EZ editatu eskuz.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Paketatutako bertsioa:** 5.5.0~ynh1
+**Paketatutako bertsioa:** 5.6.0~ynh1
 
 **Demoa:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Lecteur RSS auto-hébergé inspiré de Google Reader, basé sur Quarkus et React/TypeScript.
 
 
-**Version incluse :** 5.5.0~ynh1
+**Version incluse :** 5.6.0~ynh1
 
 **Démo :** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ NON debe editarse manualmente.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Versión proporcionada:** 5.5.0~ynh1
+**Versión proporcionada:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ Ini TIDAK boleh diedit dengan tangan.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Versi terkirim:** 5.5.0~ynh1
+**Versi terkirim:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ Hij mag NIET handmatig aangepast worden.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Geleverde versie:** 5.5.0~ynh1
+**Geleverde versie:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -20,7 +20,7 @@ Nie powinno być ono edytowane ręcznie.
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Dostarczona wersja:** 5.5.0~ynh1
+**Dostarczona wersja:** 5.6.0~ynh1
 
 **Demo:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**Поставляемая версия:** 5.5.0~ynh1
+**Поставляемая версия:** 5.6.0~ynh1
 
 **Демо-версия:** <https://www.commafeed.com/#/app/category/all>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@
 
 Google Reader inspired self-hosted RSS reader, based on Quarkus and React/TypeScript.
 
-**分发版本：** 5.5.0~ynh1
+**分发版本：** 5.6.0~ynh1
 
 **演示：** <https://www.commafeed.com/#/app/category/all>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "CommaFeed"
 description.en = "Personal RSS reader"
 description.fr = "Lecteur RSS personnel"
 
-version = "5.5.0~ynh1"
+version = "5.6.0~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -48,8 +48,8 @@ ram.runtime = "100M"
     rename = "commafeed"
     in_subdir = false
     extract = false
-    url = "https://github.com/Athou/commafeed/releases/download/5.5.0/commafeed-5.5.0-h2-linux-x86_64-runner"
-    sha256 = "129f3a25c2979da01fd0d2e2b2b228c75ed51b197323dde1309507916346a3f0"
+    url = "https://github.com/Athou/commafeed/releases/download/5.6.0/commafeed-5.6.0-h2-linux-x86_64-runner"
+    sha256 = "c3f2b3464f5a90e3ec259d4e4d1572501af83bc6ff197f9aac19737a4e6149bc"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "commafeed-\\d+\\.\\d+\\.\\d+-h2-linux-x86_64-runner"

--- a/tests.toml
+++ b/tests.toml
@@ -3,3 +3,17 @@
 test_format = 1.0
 
 [default]
+
+    # ------------
+    # Tests to run
+    # ------------
+
+    # -------------------------------
+    # Default args to use for install
+    # -------------------------------
+
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
+
+    test_upgrade_from.2f0635ea24138455feeade30adfa35beb6292319.name = "Upgrade from 5.5.0~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v5.6.0: https://github.com/Athou/commafeed/releases/tag/5.6.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
